### PR TITLE
fix improper webfont extension EOF -> EOT

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -199,7 +199,7 @@ gulp.task('images', function() {
 
 // Fonts
 gulp.task('fonts', function() {
-	return gulp.src(options.paths.fonts + '**/*.{ttf,woff,eof,svg}')
+	return gulp.src(options.paths.fonts + '**/*.{ttf,woff,eot,svg}')
 		.pipe(changed(options.paths.destFonts)) // Ignore unchanged files
 		.pipe(gulp.dest(options.paths.destFonts));
 });


### PR DESCRIPTION
The gulp task wasn't transferring EOT files to the dist/ folder, which was causing IE8 to not load webfonts.
