### PR TITLE
allow woff2 font

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -199,7 +199,7 @@ gulp.task('images', function() {
 
 // Fonts
 gulp.task('fonts', function() {
-	return gulp.src(options.paths.fonts + '**/*.{ttf,woff,eot,svg}')
+	return gulp.src(options.paths.fonts + '**/*.{ttf,woff,woff2,eot,svg}')
 		.pipe(changed(options.paths.destFonts)) // Ignore unchanged files
 		.pipe(gulp.dest(options.paths.destFonts));
 });


### PR DESCRIPTION
transfer over the new woff2 font standard when compiling in gulp