### PR TITLE
replace del with rimraf to fix 2.0.0 issues in api calls

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@
 
 var gulp = 				require('gulp'),
 	gutil = 			require('gulp-util'),
-	del = 				require('del'),
+	rimraf = 			require('rimraf'),
 	sass = 				require('gulp-sass'),
 	autoprefixer = 		require('gulp-autoprefixer'),
 	minifyCSS = 		require('gulp-minify-css'),
@@ -111,7 +111,7 @@ options.imagemin = {
 
 // Delete the dist directory
 gulp.task('clean', function(cb) {
-	del([options.distPath], cb);
+	rimraf(options.distPath, cb);
 });
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "devDependencies": {
     "browser-sync": "*",
-    "del": "*",
     "gulp": "*",
     "gulp-autoprefixer": "*",
     "gulp-changed": "*",
@@ -25,6 +24,7 @@
     "gulp-uglify": "*",
     "gulp-util": "*",
     "jshint-stylish": "*",
+    "rimraf": "*",
     "susy": "*"
   }
 }


### PR DESCRIPTION
del@2.0.0 has changed their API calls to the new Promise JS, but it seems like it caused an issue with how callbacks are executed. I've substituted del with rimraf and the problem seems to be rectified.